### PR TITLE
Collision bug

### DIFF
--- a/mumerge/mumerge.py
+++ b/mumerge/mumerge.py
@@ -359,8 +359,10 @@ def log_initializer(
     files.
     '''
     # Write to miscall and log files
-    miscallfile.write("# This file contains regions which were identified not "
-                    "to contain a tfit call after merging. Hand check these.")
+    miscallfile.write("# This file contains regions which were either overlap "
+                    "with a neighboring region (i.e. a 'collision') or were "
+                    " identified not to contain a tfit call after merging. "
+                    "You may want to manually check these.")
 
     logfile.write("Running: {}\n".format(sys.argv[0]))
     logfile.write("Python:\n{}\n".format(sys.version))
@@ -456,7 +458,7 @@ def tfit_dict_initializer(interest_regions,
             chromosome = region[0]
             start = int(region[1])
             stop = int(region[2])
-            
+
             tfit_dict[chromosome][(start, stop)] = []
     
     elif chromosome_flag and not bed_region_flag:
@@ -529,6 +531,8 @@ def tfit_file_reader(filename, sampid, tfit_dict):
                     tfit_dict[chromosome][region_key].append(val)
                 except StopIteration:
                     continue
+    
+    # {'chr#': {(reg_start, reg_stop): [start, stop, cov, sampid], ... }, ... }
     return tfit_dict
 
 
@@ -596,6 +600,7 @@ def mu_dict_generator(tfit_filenames,
     for (sampid, file) in id_and_files:
         tfit_dict = tfit_file_reader(file, sampid, tfit_dict)
     
+    # {'chr#': {(reg_start, reg_stop): [start, stop, cov, sampid], ... }, ... }
     return dict(tfit_dict)
 
 
@@ -872,8 +877,8 @@ def collision_resolver(mu_sig_list, chromosome, log=None):
         sig2 = mus[i+1][1]
 
         # Determine if mu_i and mu_i+1 overlap with one another
-        region1 = (pos1-sig1, pos1+sig1)
-        region2 = (pos2-sig2, pos2+sig2)
+        region1 = (round(pos1-sig1), round(pos1+sig1))
+        region2 = (round(pos2-sig2), round(pos2+sig2))
         if overlap_check(region1, region2):
             
             if log:

--- a/mumerge/mumerge.py
+++ b/mumerge/mumerge.py
@@ -374,7 +374,7 @@ def log_initializer(
     miscallfile.write("# This file contains regions which were either overlap "
                     "with a neighboring region (i.e. a 'collision') or were "
                     " identified not to contain a tfit call after merging. "
-                    "You may want to manually check these.")
+                    "You may want to manually check these.\n")
 
     logfile.write("Running: {}\n".format(sys.argv[0]))
     logfile.write("Python:\n{}\n".format(sys.version))
@@ -520,6 +520,7 @@ def tfit_file_reader(filename, sampid, tfit_dict):
             except Exception:
                 print("No region found...")     # CHANGE THIS!!!
 
+            # After processing the first non-header line, we can now loop. 
             # Loop over all the lines in tfit file and compare the to regions 
             # in dict
             for line in f:

--- a/mumerge/mumerge.py
+++ b/mumerge/mumerge.py
@@ -833,22 +833,24 @@ def sigma_assigner(new_mu, old_mu_sig):
 
 
 ###############################################################################
-## This function resolves collisions between newly calculated bed intervals 
-# (i.e. the new mu-sig). If two overlap, then the intervals are shrunk to 
-# where the intervals touch.
 def collision_resolver(mu_sig_list, chromosome, log=None):
     '''
-    Takes input list of (mu, sig, ...) tuples and evaluates if any of them are 
-    overlapping. In the event they do, they are shrunk to the point that they 
-    just touch. This is done in a L-to-R parse (so a doubly-overlapping region 
-    may not end up directly adjacent to its lefthand neighbor). Scaling is 
-    performed based on the relative lenghs of the two neighboring bed regions. 
-    This function also checks if any bed regions have negative coordinates and 
-    then adjusts their size so they start at bp = 0.
+    Takes input list of [(mu, sig, ...), ... ] tuples and evaluates if any of 
+    them are overlapping. In the event they do, they are shrunk to the point 
+    that they just touch. This is done in a L-to-R parse (so a 
+    doubly-overlapping region may not end up directly adjacent to its lefthand 
+    neighbor). Scaling is performed based on the relative lenghs of the two 
+    neighboring bed regions. This function also checks if any bed regions have 
+    negative coordinates and then adjusts their size so they start at bp = 0.
     '''
-    # Make sure mu_sig_list is sorted by mu position: [(mu, sig, ...), ...]
+    # Make sure mu_sig_list is sorted by mu position: [(mu, sig, ...), ... ]
     mus = sorted(mu_sig_list, key=lambda x: x[0])
 
+    # no collisions possible if there is only one mu in the list
+    if len(mus) <= 1:
+        return mus
+
+    # sliding window through list of sorted mus
     for i, mu in enumerate(mus[:-1]):
 
         pos1 = mus[i][0]
@@ -857,10 +859,12 @@ def collision_resolver(mu_sig_list, chromosome, log=None):
         sig2 = mus[i+1][1]
 
         # Determine if mu_i and mu_i+1 overlap with one another
-        if overlap_check((pos1-sig1, pos1+sig1), (pos2-sig2, pos2+sig2)):
+        region1 = (pos1-sig1, pos1+sig1)
+        region2 = (pos2-sig2, pos2+sig2)
+        if overlap_check(region1, region2):
             
             if log:
-                log.write(f"{chromosome}\t{mu[i]}/{mu[i+1]}\tcollision\n")
+                log.write(f"{chromosome}\t{region1}/{region2}\tcollision\n")
 
             # Calculate distance and ratio of length between adjacent mu
             len_ratio = sig1 / (sig1 + sig2)
@@ -876,12 +880,12 @@ def collision_resolver(mu_sig_list, chromosome, log=None):
             pass
         
         # Determine if mu_i has negative coordinates (region near start of chr)
-        left_edge = mus[i][0] - mus[i][1]
+        left_edge = region1[0]
 
         if left_edge < 0:
 
             if log:
-                log.write(f"{chromosome}\t{mu[i]}\tnegative\n")
+                log.write(f"{chromosome}\t{region1}\tnegative\n")
 
             new_sig = mus[i][1] + left_edge
             # reassign mu_i


### PR DESCRIPTION
Ru identified an issue with the logging of colliding regions. This bug precipitated this branch+merge, which also contains fixes to some other related bugs as well as the addition of a new feature, and will become a new version `v1.1.0`.  This merge fixes several bugs and adds one new feature:

BUGS:
* Fixes collision logging bug (was printing the wrong variable---e.g. `mus[i]` instead of `region1`
* Rounds the coordinates of those collision regions being printed to the miscalls file
* Changes the way the chromosome names are initialized (done in function tfit_dict_initializer() using the interest_regions argument). It wasn't wrong before, per se, but it was a bit confusing. It's now cleaned up.
* The `collision_resolver()` function was not correctly accounting for the `width_ratio` value when it readjusted overlapping regions. This could lead to regions either continuing to overlap or not touching after adjustment (depending on if `width_ratio` was less than or greater than 1.0)

FEATURES:
* Added a new input parameter (`--save_sampids` flag) which will include a list of sample IDs of any sample that contributes to the calculation of a given output merged region. This comma separated list is saved in the fourth column of the output file. A sample is considered to "contribute" to a region if it has a peak in the same group that is used to produce the mumerged output region (i.e. it contains a bed call in the same bedtools merge region).